### PR TITLE
Replace 7z action with native CLI usage and GitHub CLI for release up…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,17 +71,20 @@ jobs:
               if: matrix.os != 'windows'
               run: xz -9 sonic-*-*
 
-            - name: Compress 7z
+            - name: Compress 7z (verified path via system 7zip)
               if: matrix.os == 'windows'
-              uses: edgarrc/action-7z@93485892b5468e89cfb2c28a8d1c0e3904906458 # v1.0.5
-              with:
-                 args: 7z a -t7z -mx=9 sonic-${{matrix.os}}-${{matrix.architecture}}.7z sonic-${{matrix.os}}-${{matrix.architecture}}
+              run: |
+                sudo apt-get update
+                sudo apt-get install -y p7zip-full
+                7z a -t7z -mx=9 "sonic-${{ matrix.os }}-${{ matrix.architecture }}.7z" "sonic-${{ matrix.os }}-${{ matrix.architecture }}.exe"
 
-            - name: Upload Release
-              uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
-              with:
-                  files: |
-                      sonic-*-*.7z
-                      sonic-*-*.xz
-                      SonicWeb*.rpm
-                      SonicWeb*.deb
+            - name: Upload Release (via GitHub CLI)
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                gh release upload "${{ github.event.release.tag_name }}" \
+                  sonic-*-*.7z \
+                  sonic-*-*.xz \
+                  SonicWeb*.rpm \
+                  SonicWeb*.deb \
+                  --clobber

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 
 IGOOS=       $(shell go env GOOS)
 IGOARCH=     $(shell go env GOARCH)
+EXEC_SUFFIX= $(if $(filter windows,$(IGOOS)),.exe,)
 ICGO_ENABLED=$(if $(CGO_ENABLED),$(CGO_ENABLED),0)
 IBUILDTAG=   $(shell git describe --tags)
 PATH:=       $(PATH):$(shell go env GOPATH)/bin
@@ -17,7 +18,7 @@ SOURCES=     $(shell go list -f $(SOURCES_FMT) ./... ) logo.tmpl
 
 .PHONY: all clean docker test tls
 
-all: sonic-$(IGOOS)-$(IGOARCH)
+all: sonic-$(IGOOS)-$(IGOARCH)$(EXEC_SUFFIX)
 docker: docker-linux-amd64
 package: SonicWeb-$(IGOOS)-$(IGOARCH)-$(IBUILDTAG).deb SonicWeb-$(IGOOS)-$(IGOARCH)-$(IBUILDTAG).rpm
 helm: SonicWeb-$(IBUILDTAG).tgz


### PR DESCRIPTION
…loads; adjust Windows build output with `.exe` suffix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build**
  * Windows release binaries now include the .exe suffix for easier identification and execution.
* **Chores**
  * Streamlined release packaging to use system 7zip, improving reliability of archives.
  * Switched release uploads to GitHub CLI for more consistent asset publishing (overwrites existing assets when re-releasing).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->