### PR TITLE
Enhance release workflow: add multi-OS runner support, refine 7z comp…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,14 @@ jobs:
                 exclude:
                     - os: darwin
                       architecture: 386
-        runs-on: ubuntu-latest
+                include:
+                    - os: linux
+                      runner: ubuntu-latest
+                    - os: windows
+                      runner: windows-latest
+                    - os: darwin
+                      runner: macos-latest
+        runs-on: ${{ matrix.runner }}
         steps:
             - name: Harden Runner
               uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -71,14 +78,16 @@ jobs:
               if: matrix.os != 'windows'
               run: xz -9 sonic-*-*
 
-            - name: Compress 7z (verified path via system 7zip)
+            - name: Compress 7z (Windows)
               if: matrix.os == 'windows'
+              shell: powershell
               run: |
-                sudo apt-get update
-                sudo apt-get install -y p7zip-full
-                7z a -t7z -ssw -mx=9 "sonic-${{ matrix.os }}-${{ matrix.architecture }}.7z" "sonic-${{ matrix.os }}-${{ matrix.architecture }}.exe"
+                $sevenZip = "C:\Program Files\7-Zip\7z.exe"
+                if (-Not (Test-Path $sevenZip)) { throw "7-Zip not found at $sevenZip" }
+                & $sevenZip a -t7z -ssw -mx=9 "sonic-${{ matrix.os }}-${{ matrix.architecture }}.7z" "sonic-${{ matrix.os }}-${{ matrix.architecture }}.exe"
 
             - name: Upload Non-Windows Release (via GitHub CLI)
+              if: matrix.os != 'windows'
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
@@ -87,3 +96,12 @@ jobs:
                 do
                     gh release upload "${{ github.event.release.tag_name }}" "$file" --clobber
                 done
+
+            - name: Upload Windows Release (via GitHub CLI)
+              if: matrix.os == 'windows'
+              shell: powershell
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                $tag = "${{ github.event.release.tag_name }}"
+                Get-ChildItem -File -Path . -Filter 'sonic-*-*.7z' | ForEach-Object { gh release upload $tag $_.FullName --clobber }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,9 @@ jobs:
 
             - name: Build
               env:
-                CGO_ENABLED: "0"
-                GOOS: ${{matrix.os}}
-                GOARCH: ${{matrix.architecture}}
+                  CGO_ENABLED: "0"
+                  GOOS: ${{matrix.os}}
+                  GOARCH: ${{matrix.architecture}}
               run: make
 
             - name: Build Package
@@ -82,26 +82,26 @@ jobs:
               if: matrix.os == 'windows'
               shell: powershell
               run: |
-                $sevenZip = "C:\Program Files\7-Zip\7z.exe"
-                if (-Not (Test-Path $sevenZip)) { throw "7-Zip not found at $sevenZip" }
-                & $sevenZip a -t7z -ssw -mx=9 "sonic-${{ matrix.os }}-${{ matrix.architecture }}.7z" "sonic-${{ matrix.os }}-${{ matrix.architecture }}.exe"
+                  $sevenZip = "C:\Program Files\7-Zip\7z.exe"
+                  if (-Not (Test-Path $sevenZip)) { throw "7-Zip not found at $sevenZip" }
+                  & $sevenZip a -t7z -ssw -mx=9 "sonic-${{ matrix.os }}-${{ matrix.architecture }}.7z" "sonic-${{ matrix.os }}-${{ matrix.architecture }}.exe"
 
             - name: Upload Non-Windows Release (via GitHub CLI)
               if: matrix.os != 'windows'
               env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                shopt -s nullglob
-                for file in sonic-*-* SonicWeb*.rpm SonicWeb*.deb
-                do
-                    gh release upload "${{ github.event.release.tag_name }}" "$file" --clobber
-                done
+                  shopt -s nullglob
+                  for file in sonic-*-* SonicWeb*.rpm SonicWeb*.deb
+                  do
+                      gh release upload "${{ github.event.release.tag_name }}" "$file" --clobber
+                  done
 
             - name: Upload Windows Release (via GitHub CLI)
               if: matrix.os == 'windows'
               shell: powershell
               env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                $tag = "${{ github.event.release.tag_name }}"
-                Get-ChildItem -File -Path . -Filter 'sonic-*-*.7z' | ForEach-Object { gh release upload $tag $_.FullName --clobber }
+                  $tag = "${{ github.event.release.tag_name }}"
+                  Get-ChildItem -File -Path . -Filter 'sonic-*-*.7z' | ForEach-Object { gh release upload $tag $_.FullName --clobber }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
               if: matrix.os == 'linux'
               run: |
                   go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.43.0
-                  echo "$(go env GOPATH)/bin" >> GITHUB_PATH
+                  echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
             - name: Checkout
               uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -76,7 +76,7 @@ jobs:
 
             - name: Compress xz
               if: matrix.os != 'windows'
-              run: xz -9 sonic-*-*
+              run: xz -T0 -9 sonic-*-*
 
             - name: Compress 7z (Windows)
               if: matrix.os == 'windows'
@@ -84,12 +84,13 @@ jobs:
               run: |
                   $sevenZip = "C:\Program Files\7-Zip\7z.exe"
                   if (-Not (Test-Path $sevenZip)) { throw "7-Zip not found at $sevenZip" }
-                  & $sevenZip a -t7z -ssw -mx=9 "sonic-${{ matrix.os }}-${{ matrix.architecture }}.7z" "sonic-${{ matrix.os }}-${{ matrix.architecture }}.exe"
+                  & $sevenZip a -t7z -ssw -mmt=on -mx=9 "sonic-${{ matrix.os }}-${{ matrix.architecture }}.7z" "sonic-${{ matrix.os }}-${{ matrix.architecture }}.exe"
 
             - name: Upload Non-Windows Release (via GitHub CLI)
               if: matrix.os != 'windows'
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              shell: bash
               run: |
                   shopt -s nullglob
                   for file in sonic-*-* SonicWeb*.rpm SonicWeb*.deb
@@ -103,5 +104,9 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
+                  Set-StrictMode -Version Latest
+                  $ErrorActionPreference = 'Stop'
                   $tag = "${{ github.event.release.tag_name }}"
-                  Get-ChildItem -File -Path . -Filter 'sonic-*-*.7z' | ForEach-Object { gh release upload $tag $_.FullName --clobber }
+                  Get-ChildItem -File -Path . -Filter 'sonic-*-*.7z' | ForEach-Object {
+                      gh release upload $tag $_.FullName --clobber
+                  }

--- a/README.md
+++ b/README.md
@@ -275,5 +275,6 @@ make
 If your operating system does not provide a usable form of `make`, you can also do:
 
 ```sh
+go get
 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w"
 ```


### PR DESCRIPTION
…ression for Windows, and separate platform-specific upload steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added official Windows release artifacts (.7z) alongside Linux and macOS.

- Chores
  - CI updated to run builds on Linux, Windows, and macOS runners and to package/upload artifacts per OS (Windows uses 7z + PowerShell upload).

- Documentation
  - Build instructions updated to include a prerequisite step to fetch Go dependencies (go get).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->