### PR TITLE
Enable fuzz testing action.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,7 +148,10 @@ jobs:
             uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
             with:
                 name: testdata
-                path: testdata
+                if-no-files-found: ignore
+                path: |
+                    **/testdata/fuzz/**
+                    **/testdata/**
 
           - run: echo "EVENT NAME IS ${{ github.event_name }}"
             if: failure()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled fuzz testing in CI with a dedicated job running Go fuzz tests (30s fuzz time, 10s minimize) on stable Go for Linux.
  * Consolidated from per-package runs to a single fuzz-only invocation; preserves artifact uploads, logs, and result messaging.
* **Chores**
  * Removed deprecated commented fuzz block from the workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->