### PR TITLE
Add provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,8 +226,10 @@ jobs:
                   ls -lah
 
             - name: Generate Checksums
-              run: sha256sum * | base64 -w0 > check.sha256
               working-directory: release-assets
+              run: |
+                  set -euo pipefail
+                  sha256sum -- * | base64 -w0 | tee check.sha256 > /dev/null
 
             - name: Upload Checksums
               id: hashes
@@ -261,7 +263,7 @@ jobs:
         name: Container Provenance (immutable tag)
         uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 #must have semver!
         with:
-            # gleiche Manifest-Digest, aber der immutable Tag als Referenz
+            # same manifest digest, but referenced via the immutable tag
             image:             ${{ needs.BuildDockerMultiArch.outputs.imageName }}:${{ github.event.release.tag_name }}-${{ github.sha }}
             digest:            ${{ needs.BuildDockerMultiArch.outputs.digest }}
             registry-username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,4 +277,4 @@ jobs:
         uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 #must have semver!
         with:
             base64-subjects-as-file: "${{ needs.ChecksumReleaseAssets.outputs.base64hashes }}"
-            upload-assets: 'true'
+            upload-assets: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,7 +226,7 @@ jobs:
                   ls -lah
 
             - name: Generate Checksums
-              run: sha256sum * > check.sha256
+              run: sha256sum * | base64 -w0 > check.sha256
               working-directory: release-assets
 
             - name: Upload Checksums

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,7 @@ jobs:
               run: |
                   set -euo pipefail
                   # Robustly hash all regular files in this directory, then base64 and write via tee.
-                  find . -maxdepth 1 -type f -printf '%P\0' \
+                  LC_ALL=C find . -maxdepth 1 -type f -printf '%P\0' \
                     | sort -z \
                     | xargs -0 sha256sum -- \
                     | base64 -w0 \
@@ -287,3 +287,4 @@ jobs:
         with:
             base64-subjects-as-file: "${{ needs.ChecksumReleaseAssets.outputs.hashBase64File }}"
             upload-assets: true
+            upload-tag-name: "${{ github.event.release.tag_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,7 @@ jobs:
         needs: Build
         outputs:
             digest: ${{ steps.docker_build.outputs.digest }}
+            imageName: ${{ steps.vars.outputs.IMAGE_NAME}}
         steps:
             - name: Harden Runner
               uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -139,9 +140,11 @@ jobs:
                   egress-policy: audit
 
             - name: Generate Variables
+              id: vars
               shell: bash
               run: |
                   echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+                  echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
             - name: Checkout
               uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -242,7 +245,7 @@ jobs:
         name: Container Provenance
         uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 #must have semver!
         with:
-            image:             ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
+            image:             ${{ needs.BuildDockerMultiArch.outputs.imageName }}:${{ github.event.release.tag_name }}
             digest:            ${{ needs.BuildDockerMultiArch.outputs.digest }}
             registry-username: ${{ github.actor }}
         secrets:
@@ -259,7 +262,7 @@ jobs:
         uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 #must have semver!
         with:
             # gleiche Manifest-Digest, aber der immutable Tag als Referenz
-            image:             ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}-${{ github.sha }}
+            image:             ${{ needs.BuildDockerMultiArch.outputs.imageName }}:${{ github.event.release.tag_name }}-${{ github.sha }}
             digest:            ${{ needs.BuildDockerMultiArch.outputs.digest }}
             registry-username: ${{ github.actor }}
         secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,8 +230,12 @@ jobs:
               working-directory: release-assets
               run: |
                   set -euo pipefail
-                  sha256sum -- `LC_ALL=C ls` | base64 -w0 | tee check.sha256 > /dev/null
-
+                  # Robustly hash all regular files in this directory, then base64 and write via tee.
+                  find . -maxdepth 1 -type f -printf '%P\0' \
+                    | sort -z \
+                    | xargs -0 sha256sum -- \
+                    | base64 -w0 \
+                    | tee check.sha256 > /dev/null
             - name: Upload Checksums
               id: hashes
               uses: slsa-framework/slsa-github-generator/actions/generator/generic/create-base64-subjects-from-file@v2.1.0 #must have semver!

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,45 @@ jobs:
                   docker manifest inspect "${IMAGE_NAME}:${{ github.event.release.tag_name }}-${{ github.sha }}"
                   docker manifest inspect "${IMAGE_NAME}:latest"
 
+    ChecksumReleaseAssets:
+        needs: Build
+        runs-on: ubuntu-latest
+        name: Checksum Release Assets
+        outputs:
+            base64hashes: ${{ steps.hashes.outputs.handle }}
+        steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+              with:
+                  egress-policy: audit
+
+            - name: Checkout
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+              with:
+                  fetch-depth: 1
+
+            - name: Download all release assets via GitHub CLI
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  mkdir -p release-assets
+                  cd release-assets
+                  # gets all assets of the release
+                  gh release download "${{ github.event.release.tag_name }}" --clobber
+                  echo "Downloaded assets:"
+                  ls -lah
+
+            - name: Generate Checksums
+              run: sha256sum * > check.sha256
+              working-directory: release-assets
+
+            - name: Upload Checksums
+              id: hashes
+              uses: slsa-framework/slsa-github-generator/actions/generator/generic/create-base64-subjects-from-file@v2.1.0 #must have semver!
+              with:
+                  path: release-assets/check.sha256
+
     ContainerProvenance:
         permissions:
             actions:  read  # for detecting the GitHub Actions environment.
@@ -225,3 +264,13 @@ jobs:
             registry-username: ${{ github.actor }}
         secrets:
             registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+    AssetProvenance:
+        permissions:
+            actions:  read  # Needed for detection of GitHub Actions environment.
+            id-token: write # Needed for provenance signing and ID
+            contents: write # Needed for release uploads
+        needs: ChecksumReleaseAssets
+        uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 #must have semver!
+        with:
+            base64-subjects-as-file: "${{ needs.ChecksumReleaseAssets.outputs.base64hashes }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,7 @@ jobs:
 
             - name: Inspect final manifests
               run: |
+                  set -euo pipefail
                   docker manifest inspect "${IMAGE_NAME}:${{ github.event.release.tag_name }}"
                   docker manifest inspect "${IMAGE_NAME}:${{ github.event.release.tag_name }}-${{ github.sha }}"
                   docker manifest inspect "${IMAGE_NAME}:latest"
@@ -201,7 +202,7 @@ jobs:
         runs-on: ubuntu-latest
         name: Checksum Release Assets
         outputs:
-            base64hashes: ${{ steps.hashes.outputs.handle }}
+            hashBase64File: ${{ steps.hashes.outputs.handle }}
         steps:
             - name: Harden Runner
               uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -229,7 +230,7 @@ jobs:
               working-directory: release-assets
               run: |
                   set -euo pipefail
-                  sha256sum -- * | base64 -w0 | tee check.sha256 > /dev/null
+                  sha256sum -- `LC_ALL=C ls` | base64 -w0 | tee check.sha256 > /dev/null
 
             - name: Upload Checksums
               id: hashes
@@ -245,6 +246,7 @@ jobs:
         needs:
             - BuildDockerMultiArch
         name: Container Provenance
+        if: startsWith(github.ref, 'refs/tags/')
         uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 #must have semver!
         with:
             image:             ${{ needs.BuildDockerMultiArch.outputs.imageName }}:${{ github.event.release.tag_name }}
@@ -261,6 +263,7 @@ jobs:
         needs:
             - BuildDockerMultiArch
         name: Container Provenance (immutable tag)
+        if: startsWith(github.ref, 'refs/tags/')
         uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 #must have semver!
         with:
             # same manifest digest, but referenced via the immutable tag
@@ -278,5 +281,5 @@ jobs:
         needs: ChecksumReleaseAssets
         uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 #must have semver!
         with:
-            base64-subjects-as-file: "${{ needs.ChecksumReleaseAssets.outputs.base64hashes }}"
+            base64-subjects-as-file: "${{ needs.ChecksumReleaseAssets.outputs.hashBase64File }}"
             upload-assets: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,8 @@ jobs:
             packages: write
         runs-on: ubuntu-latest
         needs: Build
+        outputs:
+            digest: ${{ steps.docker_build.outputs.digest }}
         steps:
             - name: Harden Runner
               uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -167,6 +169,7 @@ jobs:
                   path: .
 
             - name: Build Docker Image
+              id: docker_build
               uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
               with:
                   context: .
@@ -181,9 +184,44 @@ jobs:
                       CREATED=${{ github.event.release.created_at }}
                   tags: |
                       ${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+                      ${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}-${{ github.sha }}
                       ${{ env.IMAGE_NAME }}:latest
 
             - name: Inspect final manifests
               run: |
                   docker manifest inspect "${IMAGE_NAME}:${{ github.event.release.tag_name }}"
+                  docker manifest inspect "${IMAGE_NAME}:${{ github.event.release.tag_name }}-${{ github.sha }}"
                   docker manifest inspect "${IMAGE_NAME}:latest"
+
+    ContainerProvenance:
+        permissions:
+            actions:  read  # for detecting the GitHub Actions environment.
+            id-token: write # for creating OIDC tokens for signing.
+            packages: write # for uploading attestations.
+        needs:
+            - BuildDockerMultiArch
+        name: Container Provenance
+        uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 #must have semver!
+        with:
+            image:             ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
+            digest:            ${{ needs.BuildDockerMultiArch.outputs.digest }}
+            registry-username: ${{ github.actor }}
+        secrets:
+            registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+    ContainerProvenanceImmutable:
+        permissions:
+            actions:  read
+            id-token: write
+            packages: write
+        needs:
+            - BuildDockerMultiArch
+        name: Container Provenance (immutable tag)
+        uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 #must have semver!
+        with:
+            # gleiche Manifest-Digest, aber der immutable Tag als Referenz
+            image:             ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}-${{ github.sha }}
+            digest:            ${{ needs.BuildDockerMultiArch.outputs.digest }}
+            registry-username: ${{ github.actor }}
+        secrets:
+            registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,3 +277,4 @@ jobs:
         uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 #must have semver!
         with:
             base64-subjects-as-file: "${{ needs.ChecksumReleaseAssets.outputs.base64hashes }}"
+            upload-assets: 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Release 1.6.1
 =============
 
-- added asset and container prevenance
+- added asset and container provenance
 
 Release 1.6.0
 =============

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- SPDX-FileCopyrightText: 2025 The SonicWeb contributors.
      SPDX-License-Identifier: MPL-2.0
 -->
+Release 1.6.1
+=============
+
+- added asset and container prevenance
 
 Release 1.6.0
 =============


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Publish base64-encoded SHA-256 checksums for release assets.
  - Provide SLSA provenance attestations for container images (including immutable-tag variants) and for release assets.

- Chores
  - Expand release workflow to expose and propagate built image metadata (image name, digest, immutable reference) and to inspect additional SHA-tagged manifests.
  - Add CI jobs to download assets, generate/upload checksums, and produce container/asset provenance attestations.

- Documentation
  - Added Release 1.6.1 entry to CHANGELOG.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->